### PR TITLE
#46 大引け後OHLCバッチエクスポート処理を実装する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,9 +18,10 @@ Linuxへの移植、Dockerコンテナ化、クロスプラットフォーム対
 
 ```bash
 cd src
-python main.py              # スキャルピングメイン処理
-python gui.py               # GUI注文ツール
-python board_record.py      # 板情報記録
+python main.py                    # スキャルピングメイン処理
+python gui.py                     # GUI注文ツール
+python board_rest_collector.py    # REST APIポーリングで板情報スナップショットを記録（boards テーブル or CSV）
+python ohlc_push_collector.py     # WebSocket PUSHで1分足OHLCを収集（ohlc テーブル）
 python yutai.py [証券コード] [株数] [信用種別]  # 信用返済成行注文
 ```
 
@@ -41,7 +42,7 @@ python src/analytics/catboost_reg.py
 ## アーキテクチャ — 呼び出し方向の制約
 
 ```
-Controller (src/main.py, gui.py, board_record.py, yutai.py)
+Controller (src/main.py, gui.py, board_rest_collector.py, ohlc_push_collector.py, yutai.py)
     ↓ 継承
 Base (src/base.py)
     ↓ インスタンス生成

--- a/src/board_rest_collector.py
+++ b/src/board_rest_collector.py
@@ -3,8 +3,8 @@ import json
 import time
 from base import Base
 
-class BoardRecord(Base):
-    '''板情報をDBに保存するための処理のテストコード'''
+class BoardRestCollector(Base):
+    '''REST APIポーリングで板情報スナップショットを収集し、DBまたはCSVに記録する'''
     def __init__(self):
         # 初期設定(親クラスのinit実行と、記録先に応じてDB接続を行う)
         if config.BOARD_RECORD_DB == 1:
@@ -110,5 +110,5 @@ class BoardRecord(Base):
         return True
 
 if __name__ == '__main__':
-    m = BoardRecord()
+    m = BoardRestCollector()
     m.main()

--- a/src/db/ohlc.py
+++ b/src/db/ohlc.py
@@ -265,6 +265,70 @@ class Ohlc():
             self.log.error(f'四本値テーブルのレコード更新処理でエラー\n{e}\n{traceback.format_exc()}')
             return False
 
+    def select_by_date(self, symbol, target_date):
+        '''
+        四本値テーブル(ohlc)から指定銘柄・指定日の全レコードを取得する
+
+        Args:
+            symbol(str): 銘柄コード
+            target_date(str): 取得対象日 'YYYYMMDD'
+
+        Returns:
+            result(bool): SQL実行結果
+            rows(list[dict]) or None: 取得レコードのリスト ※レコードが存在しない場合は空リスト
+        '''
+        try:
+            with self.conn.cursor(self.dict_return) as cursor:
+                sql = '''
+                    SELECT
+                        *
+                    FROM
+                        ohlc
+                    WHERE
+                        symbol = %s
+                    AND
+                        DATE(trade_time) = DATE(%s)
+                    ORDER BY
+                        trade_time ASC
+                '''
+
+                cursor.execute(sql, (symbol, target_date))
+                rows = cursor.fetchall()
+
+                if rows is None:
+                    return True, []
+                return True, list(rows)
+        except Exception as e:
+            self.log.error(f'四本値レコード日付指定取得処理でエラー\n{e}\n{traceback.format_exc()}')
+            return False, None
+
+    def delete_by_date(self, target_date):
+        '''
+        四本値テーブル(ohlc)から指定日の全レコードを削除する（全銘柄）
+
+        Args:
+            target_date(str): 削除対象日 'YYYYMMDD'
+
+        Returns:
+            result(bool): SQL実行結果
+            row_count(int): 削除件数
+        '''
+        try:
+            with self.conn.cursor() as cursor:
+                sql = '''
+                    DELETE FROM ohlc
+                    WHERE
+                        DATE(trade_time) = DATE(%s)
+                '''
+
+                cursor.execute(sql, (target_date,))
+                row_count = cursor.rowcount
+
+            return True, row_count
+        except Exception as e:
+            self.log.error(f'四本値レコード日付指定削除処理でエラー\n{e}\n{traceback.format_exc()}')
+            return False, 0
+
     def upsert(self, ohlc_data):
         '''
         四本値テーブル(ohlc)のレコードを追加または更新する

--- a/src/ohlc_push_collector.py
+++ b/src/ohlc_push_collector.py
@@ -28,6 +28,13 @@ class OhlcPushCollector(Base):
             self.log.error(f'WebSocket接続でエラー\n{e}\n{traceback.format_exc()}')
             return False
 
+        # 大引け後バッチ: ohlcテーブル → CSV出力(1分/3分/5分足) → 7z圧縮 → DB削除
+        result = self.service.collect.ohlc_export.export(
+            target_code_list, self.service.collect.record.today
+        )
+        if result == False:
+            return False
+
 if __name__ == "__main__":
     rw = OhlcPushCollector()
     asyncio.run(rw.main())

--- a/src/ohlc_push_collector.py
+++ b/src/ohlc_push_collector.py
@@ -6,15 +6,15 @@ import time
 import traceback
 from base import Base
 
-class ReceptionWebsocket(Base):
-    '''Websocketで取引情報を取得し、DBに登録する'''
+class OhlcPushCollector(Base):
+    '''WebSocket PUSHで板情報を受信し、1分足OHLCに変換してDBに登録する'''
     def __init__(self):
         super().__init__()
 
     async def main(self):
         # 初期処理(営業日判定/登録済銘柄の解除/PUSH配信を受ける銘柄の登録)
-        record_init = self.service.collect.record.record_init(config.RECORD_STOCK_CODE_LIST, config.BOARD_RECORD_DEBUG, push_mode = True)
-        if record_init == False:
+        result, target_code_list = self.service.collect.record.record_init(config.RECORD_STOCK_CODE_LIST, config.BOARD_RECORD_DEBUG, push_mode = True)
+        if result == False:
             return False
 
         # WebSocket接続/PUSH配信の受信/データのDB登録
@@ -29,5 +29,5 @@ class ReceptionWebsocket(Base):
             return False
 
 if __name__ == "__main__":
-    rw = ReceptionWebsocket()
+    rw = OhlcPushCollector()
     asyncio.run(rw.main())

--- a/src/service/collect/__init__.py
+++ b/src/service/collect/__init__.py
@@ -1,5 +1,6 @@
 from .record import Record
 from .past_record import PastRecord
+from .ohlc_export import OhlcExport
 
 
 class Collect():
@@ -9,3 +10,6 @@ class Collect():
 
         # 過去の四本値の情報取得/記録に関するクラス
         self.past_record = PastRecord()
+
+        # 大引け後OHLCエクスポートに関するクラス
+        self.ohlc_export = OhlcExport(api_headers, api_url, ws_url, conn)

--- a/src/service/collect/ohlc_export.py
+++ b/src/service/collect/ohlc_export.py
@@ -78,9 +78,10 @@ class OhlcExport(ServiceBase):
             self.log.warning(f'ohlcレコードが存在しません 銘柄コード: {symbol} 対象日: {target_date}')
             return True
 
-        # DataFrameに変換
+        # DataFrameに変換（DB管理用カラムは除外）
         df = pd.DataFrame(rows)
         df['trade_time'] = pd.to_datetime(df['trade_time'])
+        df = df.drop(columns=[col for col in ['id', 'created_at', 'updated_at'] if col in df.columns])
         df = df.sort_values('trade_time').reset_index(drop=True)
 
         # 1分足CSVを出力
@@ -124,6 +125,7 @@ class OhlcExport(ServiceBase):
         try:
             df_indexed = df.set_index('trade_time')
             resampled = df_indexed.resample(freq).agg({
+                'symbol':       'first',
                 'open_price':   'first',
                 'high_price':   'max',
                 'low_price':    'min',

--- a/src/service/collect/ohlc_export.py
+++ b/src/service/collect/ohlc_export.py
@@ -1,0 +1,158 @@
+import os
+import traceback
+import pandas as pd
+from service_base import ServiceBase
+
+
+class OhlcExport(ServiceBase):
+    '''大引け後にohlcテーブルのデータをCSVに出力し、リサンプリング・7z圧縮・DB削除を行うクラス'''
+
+    def __init__(self, api_headers, api_url, ws_url, conn):
+        super().__init__(api_headers, api_url, ws_url, conn)
+
+    def export(self, symbol_list, target_date):
+        '''
+        大引け後バッチ処理のメイン処理
+        ohlcテーブルから1分足を取得し、CSVに出力した後3分・5分足にリサンプリングする。
+        全銘柄の出力が完了したら7z圧縮し、圧縮成功時にDBのレコードを削除する。
+
+        Args:
+            symbol_list(list): 処理対象の銘柄コードリスト
+            target_date(str): 処理対象日 'YYYYMMDD'
+
+        Returns:
+            result(bool): 実行結果
+        '''
+        self.log.info(f'大引け後OHLCエクスポート処理開始 対象日: {target_date} 銘柄数: {len(symbol_list)}')
+
+        output_dir = os.path.join('..', 'csv', 'ohlc')
+
+        # 銘柄ごとにCSV出力（1分足・3分足・5分足）
+        for symbol in symbol_list:
+            result = self._export_symbol(symbol, target_date, output_dir)
+            if result == False:
+                self.log.error(f'銘柄のCSV出力処理でエラーが発生したため処理を中断します 銘柄コード: {symbol}')
+                return False
+
+        # 全銘柄のCSVを7z圧縮
+        bak_dir = os.path.join(output_dir, 'bak')
+        output_7z = os.path.join(bak_dir, f'{target_date}.7z')
+        self.log.info(f'7z圧縮処理開始 出力先: {output_7z}')
+        result, error = self.util.file_manager.compress_csv_files(output_dir, output_7z)
+        if result == False:
+            self.log.error(f'7z圧縮処理でエラーが発生したためDB削除をスキップします\n{error}')
+            return False
+        self.log.info('7z圧縮処理終了')
+
+        # 圧縮成功後にohlcテーブルの当日レコードを削除
+        self.log.info(f'ohlcテーブル削除処理開始 対象日: {target_date}')
+        result, row_count = self.db.ohlc.delete_by_date(target_date)
+        if result == False:
+            self.log.error('ohlcテーブル削除処理でエラーが発生しました')
+            return False
+        self.log.info(f'ohlcテーブル削除処理終了 削除件数: {row_count}')
+
+        self.log.info(f'大引け後OHLCエクスポート処理終了 対象日: {target_date}')
+        return True
+
+    def _export_symbol(self, symbol, target_date, output_dir):
+        '''
+        指定銘柄のohlcレコードをDBから取得し、1分・3分・5分足のCSVを出力する
+
+        Args:
+            symbol(str): 銘柄コード
+            target_date(str): 処理対象日 'YYYYMMDD'
+            output_dir(str): CSV出力先ディレクトリ
+
+        Returns:
+            result(bool): 実行結果
+        '''
+        self.log.info(f'銘柄OHLCエクスポート処理開始 銘柄コード: {symbol}')
+
+        # DBから1分足レコードを取得
+        result, rows = self.db.ohlc.select_by_date(symbol, target_date)
+        if result == False:
+            self.log.error(f'ohlcレコード取得処理でエラー 銘柄コード: {symbol}')
+            return False
+        if len(rows) == 0:
+            self.log.warning(f'ohlcレコードが存在しません 銘柄コード: {symbol} 対象日: {target_date}')
+            return True
+
+        # DataFrameに変換
+        df = pd.DataFrame(rows)
+        df['trade_time'] = pd.to_datetime(df['trade_time'])
+        df = df.sort_values('trade_time').reset_index(drop=True)
+
+        # 1分足CSVを出力
+        path_1min = os.path.join(output_dir, f'{target_date}_{symbol}_1min.csv')
+        result = self._write_csv(df, path_1min)
+        if result == False:
+            return False
+
+        # 3分足CSVを出力
+        df_3min = self._resample(df, '3min')
+        if df_3min is None:
+            return False
+        path_3min = os.path.join(output_dir, f'{target_date}_{symbol}_3min.csv')
+        result = self._write_csv(df_3min, path_3min)
+        if result == False:
+            return False
+
+        # 5分足CSVを出力
+        df_5min = self._resample(df, '5min')
+        if df_5min is None:
+            return False
+        path_5min = os.path.join(output_dir, f'{target_date}_{symbol}_5min.csv')
+        result = self._write_csv(df_5min, path_5min)
+        if result == False:
+            return False
+
+        self.log.info(f'銘柄OHLCエクスポート処理終了 銘柄コード: {symbol} レコード数: {len(df)}')
+        return True
+
+    def _resample(self, df, freq):
+        '''
+        DataFrameを指定した時間足にリサンプリングする
+
+        Args:
+            df(pd.DataFrame): 1分足データ（trade_timeカラムがdatetime型）
+            freq(str): リサンプリング間隔（例: '3min', '5min'）
+
+        Returns:
+            resampled(pd.DataFrame) or None: リサンプリング後のDataFrame
+        '''
+        try:
+            df_indexed = df.set_index('trade_time')
+            resampled = df_indexed.resample(freq).agg({
+                'open_price':   'first',
+                'high_price':   'max',
+                'low_price':    'min',
+                'close_price':  'last',
+                'volume':       'sum',
+                'total_volume': 'last',
+                'status':       'last'
+            }).dropna(subset=['open_price'])
+            resampled = resampled.reset_index()
+            return resampled
+        except Exception as e:
+            self.log.error(f'OHLCリサンプリング処理でエラー freq: {freq}\n{e}\n{traceback.format_exc()}')
+            return None
+
+    def _write_csv(self, df, file_path):
+        '''
+        DataFrameをCSVに出力する
+
+        Args:
+            df(pd.DataFrame): 出力対象のDataFrame
+            file_path(str): 出力先のファイルパス
+
+        Returns:
+            result(bool): 実行結果
+        '''
+        try:
+            df.to_csv(file_path, index=False, encoding='utf-8')
+            self.log.info(f'CSV出力処理完了 ファイルパス: {file_path} 件数: {len(df)}')
+            return True
+        except Exception as e:
+            self.log.error(f'CSV出力処理でエラー ファイルパス: {file_path}\n{e}\n{traceback.format_exc()}')
+            return False


### PR DESCRIPTION
## Summary

- `db/ohlc.py` に `select_by_date()` / `delete_by_date()` を追加
- `service/collect/ohlc_export.py` (`OhlcExport` クラス) を新規作成
  - 大引け後に ohlcテーブル → 1分/3分/5分足CSV出力 → 7z圧縮 → DB削除 のバッチ処理
- `ohlc_push_collector.py` に後場終了後のバッチ呼び出しを追加

## 処理フロー

```
ohlc_push_collector.py
  ├─ websocket_main(1)  前場（既存）
  ├─ websocket_main(2)  後場（既存）
  └─ ohlc_export.export(symbol_list, today)  ← 今回追加
       ├─ DB → 1分足CSV  csv/ohlc/{YYYYMMDD}_{symbol}_1min.csv
       ├─ リサンプリング → 3分足CSV
       ├─ リサンプリング → 5分足CSV
       ├─ 7z圧縮 → csv/ohlc/bak/{YYYYMMDD}.7z
       └─ 圧縮成功後にDB削除
```

## `_resample()` の検証

1分足DataFrameを `pandas.DataFrame.resample().agg()` で指定時間足に集約する処理について実装を検証した。

### 集約ロジック

| カラム | 集約方法 | 理由 |
|---|---|---|
| `symbol` | `first` | 銘柄コードは全行同一 |
| `open_price` | `first` | 区間最初の1分足の始値 |
| `high_price` | `max` | 区間内の最高値 |
| `low_price` | `min` | 区間内の最安値 |
| `close_price` | `last` | 区間最後の1分足の終値 |
| `volume` | `sum` | 区間内の出来高合計 |
| `total_volume` | `last` | 累積値なので最後の値を使う |
| `status` | `last` | 最終状態を採用 |

### 区間境界

pandas の `resample()` はデフォルト `closed='left'`, `label='left'`。  
「9:00の3分足」= ラベル`09:00` = `[09:00, 09:03)` の1分足（09:00, 09:01, 09:02）を集約。  
前場開始9:00・後場開始12:30はいずれも3分・5分の倍数（540÷3=180、750÷5=150）なので、市場の区切り目でちょうど新しい足が始まる。  
お昼休み（11:30〜12:29）の空区間は `.dropna(subset=['open_price'])` で除去する。

### 発見・修正したバグ

**`symbol` カラムが3/5分足CSVから消えるバグ**

`agg({...})` に指定したカラムのみが結果に残るpandasの仕様により、`agg` に含めていなかった `symbol` が3/5分足CSVから欠落していた。`'symbol': 'first'` を追加して修正。

あわせて `id`, `created_at`, `updated_at`（DB管理用カラム）をDataFrame変換直後に削除し、1分/3分/5分足の全CSVでカラム構成を統一した。

**修正前後のカラム構成:**

| カラム | 修正前 1min | 修正前 3/5min | 修正後 全足 |
|---|---|---|---|
| `symbol` | ✅ | ❌ | ✅ |
| `trade_time` | ✅ | ✅ | ✅ |
| `open_price` 〜 `status` | ✅ | ✅ | ✅ |
| `id` | ✅ (不要) | ❌ | ❌ (除外) |
| `created_at` | ✅ (不要) | ❌ | ❌ (除外) |
| `updated_at` | ✅ (不要) | ❌ | ❌ (除外) |

## Test plan

- [ ] `ohlc_push_collector.py` を実行し、後場終了後にバッチが起動することを確認
- [ ] `csv/ohlc/` 配下に `{YYYYMMDD}_{symbol}_{1,3,5}min.csv` が生成されることを確認
- [ ] 1分/3分/5分足CSVのカラム構成が `symbol, trade_time, open_price, high_price, low_price, close_price, volume, total_volume, status` で統一されていることを確認
- [ ] `csv/ohlc/bak/{YYYYMMDD}.7z` が生成され、全CSVが含まれることを確認
- [ ] `ohlc` テーブルから該当日のレコードが削除されることを確認
- [ ] 7z圧縮失敗時にDB削除がスキップされDBとCSVが保持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)