### PR TITLE
#54 注文処理での東証市場コード「1」指定を廃止

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -38,11 +38,12 @@ class StockOrderApp(Base):
         self.qty_entry.grid(row=1, column=1, sticky='e', padx=(0, 15), pady=5)
 
         # 証券取引所 (Exchange)
+        # 東証はAPIから優先市場コードを自動取得する（市場コード「1」は2026/02/28以降の発注で使用不可）
         tk.Label(self.root, text='証券取引所', **label_options).grid(row=2, column=0, sticky='w', padx=10, pady=5)
         self.exchange_var = tk.StringVar(self.root)
-        self.exchange_var.set('東証')  # デフォルト値
+        self.exchange_var.set('東証(自動取得)')  # デフォルト値
         self.exchange_map = {
-            '東証': 1,
+            '東証(自動取得)': None,  # primary_exchange APIから市場コードを取得
             '名証': 3,
             '福証': 5,
             '札証': 6,
@@ -340,6 +341,18 @@ class StockOrderApp(Base):
             qty = int(qty)
             exchange = self.exchange_map[exchange_label]
             side = self.side_map[side_label]
+        except ValueError:
+            messagebox.showerror('エラー', '数値で指定する必要がある項目があります。')
+            return
+
+        # 東証(自動取得)が選択された場合はAPIから優先市場コードを取得
+        if exchange is None:
+            result, exchange = self.service.trade.scalping.get_primary_exchange(stock_code)
+            if not result:
+                messagebox.showerror('エラー', f'優先市場コードの取得に失敗しました。\n{exchange}')
+                return
+
+        try:
             cash_margin = self.cash_margin_map[cash_margin_label]
             margin_trade_type = self.margin_trade_type_map[margin_trade_type_label]
             close_position_order = self.close_position_order_map[close_position_order_label]

--- a/src/service/trade/scalping.py
+++ b/src/service/trade/scalping.py
@@ -854,10 +854,17 @@ class Scalping(ServiceBase):
 
         self.log.info(f'信用空売り決済処理[優待用]のAPIリクエスト送信処理開始 証券コード: {stock_code}')
 
+        # 優先市場コードを取得（市場コード「1」は2026/02/28以降の発注で使用不可）
+        result, exchange_info = self.api.info.primary_exchange(stock_code)
+        if result == False:
+            self.log.error(f'信用空売り決済処理[優待用]で優先市場コード取得エラー\n証券コード: {stock_code}\n{exchange_info}')
+            return False
+        exchange = exchange_info['PrimaryExchange']
+
         order_info = {
             'Password': trade_password,    # ここはKabuStationではなくカブコムの取引パスワード
             'Symbol': str(stock_code),     # 証券コード
-            'Exchange': 1,                 # 証券所   1: 東証 (3: 名証、5: 福証、6: 札証)
+            'Exchange': exchange,          # 証券所（primary_exchange APIから取得）
             'SecurityType': 1,             # 商品種別 1: 株式 のみ指定可
             'Side': 2,                     # 売買区分 2: 買 (1: 売)
             'CashMargin': 3,               # 取引区分 3: 返済 (1: 現物、2: 新規信用)
@@ -1140,6 +1147,22 @@ class Scalping(ServiceBase):
 
         self.log.info(f'損切り売り注文処理成功 注文価格: {order_price}')
         return True
+
+    def get_primary_exchange(self, stock_code):
+        '''
+        銘柄の優先市場コードを取得する
+
+        Args:
+            stock_code(str): 証券コード
+
+        Returns:
+            result(bool): 実行結果
+            exchange(int or str): 市場コード or エラーメッセージ
+        '''
+        result, info = self.api.info.primary_exchange(stock_code)
+        if result == False:
+            return False, info
+        return True, info['PrimaryExchange']
 
     def direct_order(self, order_info):
         '''

--- a/src/util/mold.py
+++ b/src/util/mold.py
@@ -182,7 +182,8 @@ class Mold():
             password(str): 注文パスワード(≠APIパスワード)[必須]
             stock_code(str): 証券コード [必須]
             exchange(int): 市場コード [必須]
-                1: 東証、3: 名証、5: 福証、6: 札証
+                primary_exchange APIから取得した値を使用すること（3: 名証、5: 福証、6: 札証）
+                ※市場コード「1（東証）」は2026/02/28以降の新規発注で使用不可
             side(str): 売買区分 [必須]
                 1: 売、2: 買
             cash_margin(int): 信用区分 [必須]


### PR DESCRIPTION
## 対応内容

KabuStation API仕様変更（2026/02/28施行）への対応。
市場コード「1（東証）」を指定した現物・信用取引の新規発注が不可となったため、`primary_exchange` APIから動的に市場コードを取得する方式に変更。

## 修正箇所

- `src/service/trade/scalping.py` — `yutai_settlement()`でハードコードされていた`'Exchange': 1`を、`primary_exchange` APIから取得した値に変更。また、GUI向けの`get_primary_exchange()`サービスメソッドを追加
- `src/gui.py` — `exchange_map`の`'東証': 1`を`'東証(自動取得)': None`に変更し、`send_order()`でAPIから市場コードを取得するロジックを追加
- `src/util/mold.py` — `create_order_request()`の`exchange`パラメータコメントに仕様変更の注意書きを追記

## 確認事項

- [ ] `yutai_settlement()` で market_code が動的取得されること
- [ ] GUI の「東証(自動取得)」選択時に `primary_exchange` API が呼ばれること
- [ ] 名証・福証・札証 の直接指定は従来通り動作すること

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)